### PR TITLE
update go_package option for latest proto-gen-go

### DIFF
--- a/api.proto
+++ b/api.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
-option go_package = "kvapi";
+// go_package is encoded as "import_path;package_name"; for further details
+// see https://github.com/golang/protobuf/issues/1043#issuecomment-590449295
+option go_package = "kvapi;kvapi";
 
 package simplekeyvalue;
 


### PR DESCRIPTION
The latest version of proto-gen-go requires the go_package option to
explicitly state the package path; since our path isn't absolute we need
to specify the import path, followed by the package name, which are both
kvapi and thus are encoded as "kvapi;kvapi"

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>