### PR TITLE
Hook up GHA to run earthly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    name: +proto-all
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download latest released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Docker Login (non fork only)
+        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Run tests
+        run: earthly --ci +proto-all

--- a/api.proto
+++ b/api.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 // go_package is encoded as "import_path;package_name"; for further details
 // see https://github.com/golang/protobuf/issues/1043#issuecomment-590449295
-option go_package = "kvapi;kvapi";
+option go_package = "/kvapi;kvapi";
 
 package simplekeyvalue;
 


### PR DESCRIPTION
- this example is referenced by our main earthly repo in
  https://github.com/earthly/earthly/blob/main/examples/grpc/Earthfile
  however it would be nice to also be able to do some basic testing here
  to ensure the Earthfile and protos can compile

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>