### PR TITLE
fix previous proto-gen-go change which created a subdir

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -22,7 +22,11 @@ proto-go:
   COPY api.proto /defs
   RUN mkdir /defs/go-api
   RUN protoc --proto_path=/defs --go_out=/defs/go-api --go-grpc_out=/defs/go-api /defs/api.proto
-  SAVE ARTIFACT ./go-api /go-pb AS LOCAL go-pb
+  SAVE ARTIFACT ./go-api/kvapi /go-pb AS LOCAL go-pb
+
+test-proto-go:
+  COPY +proto-go/go-pb kvapi
+  RUN ls kvapi/api.pb.go
 
 proto-py:
   RUN apt-get install -y python3 python3-pip
@@ -42,6 +46,7 @@ proto-rb:
   SAVE ARTIFACT ./rb-api /rb-pb AS LOCAL rb-pb
 
 proto-all:
+  BUILD +test-proto-go
   BUILD +proto-go
   BUILD +proto-py
   BUILD +proto-rb


### PR DESCRIPTION
- the previous change to proto-gen-go caused the protofiles to be saved
under a kvapi directory which then caused it to be imported as
kvapi/kvapi/kvapi.pb.go rather than simply kvapi/kvapi.pb.go

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>