### PR TITLE
rollback ubuntu to 20.04

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:20.04
 WORKDIR /defs
 
 RUN apt-get update && apt-get install -y wget unzip


### PR DESCRIPTION
ubuntu:20.10 references deb repos which no longer exist.
under https://hub.docker.com/_/ubuntu?tab=description
20.10 isn't even listed; however 20.04 is.

Without this change we were seeing:

    g/e/earthly-example-proto:main+base *failed* | platform=linux/amd64
    g/e/earthly-example-proto:main+base *failed* | --> RUN apt-get update && apt-get install -y wget unzip
    g/e/earthly-example-proto:main+base *failed* | Ign:1 http://security.ubuntu.com/ubuntu groovy-security InRelease
    g/e/earthly-example-proto:main+base *failed* | Err:2 http://security.ubuntu.com/ubuntu groovy-security Release
    g/e/earthly-example-proto:main+base *failed* |   404  Not Found [IP: 91.189.91.39 80]
    g/e/earthly-example-proto:main+base *failed* | Ign:3 http://archive.ubuntu.com/ubuntu groovy InRelease
    g/e/earthly-example-proto:main+base *failed* | Ign:4 http://archive.ubuntu.com/ubuntu groovy-updates InRelease
    g/e/earthly-example-proto:main+base *failed* | Ign:5 http://archive.ubuntu.com/ubuntu groovy-backports InRelease
    g/e/earthly-example-proto:main+base *failed* | Err:6 http://archive.ubuntu.com/ubuntu groovy Release
    g/e/earthly-example-proto:main+base *failed* |   404  Not Found [IP: 91.189.88.152 80]
    g/e/earthly-example-proto:main+base *failed* | Err:7 http://archive.ubuntu.com/ubuntu groovy-updates Release
    g/e/earthly-example-proto:main+base *failed* |   404  Not Found [IP: 91.189.88.152 80]
    g/e/earthly-example-proto:main+base *failed* | Err:8 http://archive.ubuntu.com/ubuntu groovy-backports Release
    g/e/earthly-example-proto:main+base *failed* |   404  Not Found [IP: 91.189.88.152 80]
    g/e/earthly-example-proto:main+base *failed* | Reading package lists...
    g/e/earthly-example-proto:main+base *failed* | E: The repository 'http://security.ubuntu.com/ubuntu groovy-security Release' does not have a Release file.
    g/e/earthly-example-proto:main+base *failed* | E: The repository 'http://archive.ubuntu.com/ubuntu groovy Release' does not have a Release file.
    g/e/earthly-example-proto:main+base *failed* | E: The repository 'http://archive.ubuntu.com/ubuntu groovy-updates Release' does not have a Release file.
    g/e/earthly-example-proto:main+base *failed* | E: The repository 'http://archive.ubuntu.com/ubuntu groovy-backports Release' does not have a Release file.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>