### PR TITLE
DEBIAN_FRONTEND=noninteractive to prevent hanging

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 WORKDIR /defs
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y wget unzip
 
 # setup protoc


### PR DESCRIPTION
After rolling from 20.10 to 20.04, tzdata started
prompting for timezone config when installed via apt.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>